### PR TITLE
cmd/server: initial setup for sqlite account and transaction storage

### DIFF
--- a/cmd/server/account_storage.go
+++ b/cmd/server/account_storage.go
@@ -9,21 +9,26 @@ import (
 	"strings"
 
 	"github.com/moov-io/gl"
+
+	"github.com/go-kit/kit/log"
 )
 
 type accountRepository interface {
 	Ping() error
+	Close() error
 
 	GetAccounts(accountIds []string) ([]*gl.Account, error)
 	GetCustomerAccounts(customerId string) ([]*gl.Account, error)
-	CreateAccount(customerId string, account *gl.Account) error // TODO(adam): acctType needs strong type
+	CreateAccount(customerId string, account *gl.Account) error // TODO(adam): acctType needs strong type, we can drop customerId as it's on gl.Account
 	SearchAccounts(accountNumber, routingNumber, acctType string) (*gl.Account, error)
 }
 
-func initAccountStorage(name string) (accountRepository, error) {
+func initAccountStorage(logger log.Logger, name string) (accountRepository, error) {
 	switch strings.ToLower(name) {
 	case "qledger":
 		return setupQLedgerAccountStorage(os.Getenv("QLEDGER_ENDPOINT"), os.Getenv("QLEDGER_AUTH_TOKEN"))
+	case "sqlite":
+		return setupSqliteAccountStorage(logger, getSqlitePath())
 	}
 	return nil, nil
 }

--- a/cmd/server/account_storage_qledger.go
+++ b/cmd/server/account_storage_qledger.go
@@ -25,6 +25,10 @@ func (r *qledgerAccountRepository) Ping() error {
 	return r.api.Ping()
 }
 
+func (r *qledgerAccountRepository) Close() error {
+	return nil
+}
+
 func (r *qledgerAccountRepository) GetAccounts(accountIds []string) ([]*gl.Account, error) {
 	var terms []map[string]interface{}
 	for i := range accountIds {
@@ -121,6 +125,8 @@ func setupQLedgerAccountStorage(endpoint, apiToken string) (*qledgerAccountRepos
 func convertAccounts(accts []*mledge.Account) []*gl.Account {
 	var accounts []*gl.Account
 	for i := range accts {
+		closedAt := readTime(accts[i].Data["closedAt"].(string))
+		lastModified := readTime(accts[i].Data["lastModified"].(string))
 		accounts = append(accounts, &gl.Account{
 			ID:               accts[i].ID,
 			CustomerID:       accts[i].Data["customerId"].(string),
@@ -133,8 +139,8 @@ func convertAccounts(accts []*mledge.Account) []*gl.Account {
 			BalanceAvailable: readBalance(accts[i].Data["balanceAvailable"].(string)),
 			BalancePending:   readBalance(accts[i].Data["balancePending"].(string)),
 			CreatedAt:        readTime(accts[i].Data["createdAt"].(string)),
-			ClosedAt:         readTime(accts[i].Data["closedAt"].(string)),
-			LastModified:     readTime(accts[i].Data["lastModified"].(string)),
+			ClosedAt:         &closedAt,
+			LastModified:     &lastModified,
 		})
 	}
 	return accounts

--- a/cmd/server/account_storage_qledger_test.go
+++ b/cmd/server/account_storage_qledger_test.go
@@ -43,8 +43,8 @@ func qualifyQLedgerAccountTest(t *testing.T) *testQLedgerAccountRepository {
 
 	// repo, err := setupQLedgerAccountStorage("https://api.moov.io/v1/qledger", "moov") // Test against Production
 	repo, err := setupQLedgerAccountStorage(fmt.Sprintf("http://localhost:%s", deployment.qledger.GetPort("7000/tcp")), "moov")
-	if err != nil {
-		t.Fatal(err)
+	if repo == nil || err != nil {
+		t.Fatalf("repo=%v error=%v", repo, err)
 	}
 	return &testQLedgerAccountRepository{repo, deployment}
 }

--- a/cmd/server/account_storage_qledger_test.go
+++ b/cmd/server/account_storage_qledger_test.go
@@ -64,7 +64,8 @@ func TestQLedgerAccounts__ping(t *testing.T) {
 func TestQLedger__Accounts(t *testing.T) {
 	repo := qualifyQLedgerAccountTest(t)
 
-	customerId := base.ID()
+	customerId, now := base.ID(), time.Now()
+	future := now.Add(24 * time.Hour)
 	account := &gl.Account{
 		ID:               base.ID(),
 		CustomerID:       customerId,
@@ -76,7 +77,9 @@ func TestQLedger__Accounts(t *testing.T) {
 		Balance:          100,
 		BalancePending:   123,
 		BalanceAvailable: 412,
-		CreatedAt:        time.Now(),
+		CreatedAt:        now,
+		ClosedAt:         &future,
+		LastModified:     &now,
 	}
 	if err := repo.CreateAccount(customerId, account); err != nil {
 		t.Error(err)

--- a/cmd/server/account_storage_qledger_test.go
+++ b/cmd/server/account_storage_qledger_test.go
@@ -46,6 +46,9 @@ func qualifyQLedgerAccountTest(t *testing.T) *testQLedgerAccountRepository {
 	if repo == nil || err != nil {
 		t.Fatalf("repo=%v error=%v", repo, err)
 	}
+	if err := repo.Close(); err != nil { // should do nothing, so call in every test to make sure
+		t.Fatal("QLedger .Close() is a no-op")
+	}
 	return &testQLedgerAccountRepository{repo, deployment}
 }
 

--- a/cmd/server/account_storage_sqlite.go
+++ b/cmd/server/account_storage_sqlite.go
@@ -1,0 +1,133 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/moov-io/gl"
+
+	"github.com/go-kit/kit/log"
+)
+
+type sqliteAccountRepository struct {
+	db     *sql.DB
+	logger log.Logger
+}
+
+func setupSqliteAccountStorage(logger log.Logger, path string) (*sqliteAccountRepository, error) {
+	db, err := createSqliteConnection(logger, path)
+	if err != nil {
+		return nil, err
+	}
+	return &sqliteAccountRepository{db, logger}, nil
+}
+
+func (r *sqliteAccountRepository) Ping() error {
+	return r.db.Ping()
+}
+
+func (r *sqliteAccountRepository) Close() error {
+	return r.db.Close()
+}
+
+func (r *sqliteAccountRepository) GetAccounts(accountIds []string) ([]*gl.Account, error) {
+	if len(accountIds) > 250 {
+		return nil, fmt.Errorf("sqlite.GetAccounts: too many accountIds (%d)", len(accountIds))
+	}
+	query := fmt.Sprintf(`select account_id, customer_id, name, account_number, routing_number, status, type, created_at, closed_at, last_modified
+from accounts where account_id in (?%s) and deleted_at is null;`, strings.Repeat(",?", len(accountIds)-1))
+	stmt, err := r.db.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	var ids []interface{}
+	for i := range accountIds {
+		ids = append(ids, accountIds[i])
+	}
+	rows, err := stmt.Query(ids...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var accounts []*gl.Account
+	for rows.Next() {
+		var a gl.Account
+		err := rows.Scan(&a.ID, &a.CustomerID, &a.Name, &a.AccountNumber, &a.RoutingNumber, &a.Status, &a.Type, &a.CreatedAt, &a.ClosedAt, &a.LastModified)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite.GetAccounts: account=%q: %v", a.ID, err)
+		}
+		// TODO(adam): attach balance computations
+		accounts = append(accounts, &a)
+	}
+	return accounts, rows.Err()
+}
+
+func (r *sqliteAccountRepository) GetCustomerAccounts(customerId string) ([]*gl.Account, error) {
+	query := `select account_id from accounts where customer_id = ? and deleted_at is null;`
+	stmt, err := r.db.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(customerId)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var accountIds []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("sqlite.GetCustomerAccounts: account=%q: %v", id, err)
+		}
+		accountIds = append(accountIds, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return r.GetAccounts(accountIds)
+}
+
+func (r *sqliteAccountRepository) CreateAccount(customerId string, a *gl.Account) error {
+	query := `insert into accounts (account_id, customer_id, name, account_number, routing_number, status, type, created_at) values (?, ?, ?, ?, ?, ?, ?, ?);`
+	stmt, err := r.db.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(a.ID, a.CustomerID, a.Name, a.AccountNumber, a.RoutingNumber, a.Status, a.Type, a.CreatedAt)
+	return err
+}
+
+func (r *sqliteAccountRepository) SearchAccounts(accountNumber, routingNumber, acctType string) (*gl.Account, error) {
+	query := `select account_id from accounts where account_number = ? and routing_number = ? and type = ? and deleted_at is null limit 1;`
+	stmt, err := r.db.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	row := stmt.QueryRow(accountNumber, routingNumber, acctType)
+	var id string
+	if err := row.Scan(&id); err != nil || id == "" {
+		return nil, fmt.Errorf("sqlite.SearchAccounts: account=%q: %v", id, err)
+	}
+
+	// Grab out account by its ID
+	accounts, err := r.GetAccounts([]string{id})
+	if err != nil || len(accounts) == 0 {
+		return nil, fmt.Errorf("sqlite.SearchAccounts: no accounts: %v", err)
+	}
+	return accounts[0], nil
+}

--- a/cmd/server/account_storage_sqlite_test.go
+++ b/cmd/server/account_storage_sqlite_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -26,11 +27,26 @@ func (r *testSqliteAccountRepository) Close() error {
 }
 
 func createTestSqliteAccountRepository(t *testing.T) *testSqliteAccountRepository {
+	t.Helper()
+
 	db, err := createTestSqliteDB()
 	if err != nil {
 		t.Fatal(err)
 	}
-	return &testSqliteAccountRepository{&sqliteAccountRepository{db.db, log.NewNopLogger()}, db}
+	repo, err := setupSqliteAccountStorage(log.NewNopLogger(), filepath.Join(db.dir, "gl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &testSqliteAccountRepository{repo, db}
+}
+
+func TestSqliteAccountRepository_Ping(t *testing.T) {
+	repo := createTestSqliteAccountRepository(t)
+	defer repo.Close()
+
+	if err := repo.Ping(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestSqliteAccountRepository(t *testing.T) {

--- a/cmd/server/account_storage_sqlite_test.go
+++ b/cmd/server/account_storage_sqlite_test.go
@@ -53,7 +53,8 @@ func TestSqliteAccountRepository(t *testing.T) {
 	repo := createTestSqliteAccountRepository(t)
 	defer repo.Close()
 
-	customerId := base.ID()
+	customerId, now := base.ID(), time.Now()
+	future := now.Add(24 * time.Hour)
 	account := &gl.Account{
 		ID:            base.ID(),
 		CustomerID:    customerId,
@@ -63,6 +64,8 @@ func TestSqliteAccountRepository(t *testing.T) {
 		Status:        "open",
 		Type:          "Savings",
 		CreatedAt:     time.Now(),
+		ClosedAt:      &future,
+		LastModified:  &now,
 	}
 	if err := repo.CreateAccount(customerId, account); err != nil {
 		t.Fatal(err)

--- a/cmd/server/account_storage_sqlite_test.go
+++ b/cmd/server/account_storage_sqlite_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/moov-io/base"
+	"github.com/moov-io/gl"
+
+	"github.com/go-kit/kit/log"
+)
+
+type testSqliteAccountRepository struct {
+	*sqliteAccountRepository
+
+	db *testSqliteDB
+}
+
+func (r *testSqliteAccountRepository) Close() error {
+	r.db.close()
+	return r.sqliteAccountRepository.Close()
+}
+
+func createTestSqliteAccountRepository(t *testing.T) *testSqliteAccountRepository {
+	db, err := createTestSqliteDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &testSqliteAccountRepository{&sqliteAccountRepository{db.db, log.NewNopLogger()}, db}
+}
+
+func TestSqliteAccountRepository(t *testing.T) {
+	repo := createTestSqliteAccountRepository(t)
+	defer repo.Close()
+
+	customerId := base.ID()
+	account := &gl.Account{
+		ID:            base.ID(),
+		CustomerID:    customerId,
+		Name:          "test account",
+		AccountNumber: "12411",
+		RoutingNumber: "219871289",
+		Status:        "open",
+		Type:          "Savings",
+		CreatedAt:     time.Now(),
+	}
+	if err := repo.CreateAccount(customerId, account); err != nil {
+		t.Fatal(err)
+	}
+
+	otherAccount := &gl.Account{
+		ID:            base.ID(),
+		CustomerID:    base.ID(),
+		Name:          "other account",
+		AccountNumber: "18412481",
+		RoutingNumber: "219871289",
+		Status:        "open",
+		Type:          "Checking",
+		CreatedAt:     time.Now(),
+	}
+	if err := repo.CreateAccount(otherAccount.CustomerID, otherAccount); err != nil {
+		t.Fatal(err)
+	}
+
+	// read via one method
+	accounts, err := repo.GetAccounts([]string{account.ID})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("got %d accounts: %#v", len(accounts), accounts)
+	}
+	if accounts[0].ID != account.ID {
+		t.Errorf("Got %s", accounts[0].ID)
+	}
+
+	// and read via another
+	accounts, err = repo.GetCustomerAccounts(account.CustomerID)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("got %d accounts: %#v", len(accounts), accounts)
+	}
+	if accounts[0].ID != account.ID {
+		t.Errorf("Got %s", accounts[0].ID)
+	}
+
+	// finally via a third method
+	acct, err := repo.SearchAccounts(otherAccount.AccountNumber, otherAccount.RoutingNumber, otherAccount.Type)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acct.ID != otherAccount.ID {
+		t.Errorf("found account %q", acct.ID)
+	}
+}

--- a/cmd/server/account_storage_test.go
+++ b/cmd/server/account_storage_test.go
@@ -20,6 +20,10 @@ func (r *testAccountRepository) Ping() error {
 	return r.err
 }
 
+func (r *testAccountRepository) Close() error {
+	return r.err
+}
+
 func (r *testAccountRepository) GetAccounts(accountIds []string) ([]*gl.Account, error) {
 	if r.err != nil {
 		return nil, r.err

--- a/cmd/server/accounts.go
+++ b/cmd/server/accounts.go
@@ -106,7 +106,7 @@ func createCustomerAccount(logger log.Logger, repo accountRepository) http.Handl
 			return
 		}
 
-		customerId := getCustomerId(w, r)
+		customerId, now := getCustomerId(w, r), time.Now()
 		account := &gl.Account{
 			ID:            base.ID(),
 			CustomerID:    customerId,
@@ -115,8 +115,8 @@ func createCustomerAccount(logger log.Logger, repo accountRepository) http.Handl
 			RoutingNumber: defaultRoutingNumber,
 			Status:        "open",
 			Type:          req.Type,
-			CreatedAt:     time.Now(),
-			LastModified:  time.Now(),
+			CreatedAt:     now,
+			LastModified:  &now,
 		}
 
 		if err := repo.CreateAccount(customerId, account); err != nil {

--- a/cmd/server/accounts_test.go
+++ b/cmd/server/accounts_test.go
@@ -32,6 +32,10 @@ var (
 	}
 )
 
+func init() {
+	defaultRoutingNumber = "231380104"
+}
+
 func TestAccounts__createAccountRequest(t *testing.T) {
 	req := createAccountRequest{"example acct", "checking"}
 	if err := req.validate(); err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -96,12 +96,14 @@ func main() {
 	// Setup Account storage
 	accountStorageType := os.Getenv("ACCOUNT_STORAGE_TYPE")
 	if accountStorageType == "" {
-		accountStorageType = "qledger"
+		accountStorageType = "sqlite"
 	}
-	accountRepo, err := initAccountStorage(accountStorageType)
+	accountRepo, err := initAccountStorage(logger, accountStorageType)
 	if err != nil {
 		panic(fmt.Sprintf("account storage: %v", err))
 	}
+	defer accountRepo.Close()
+	logger.Log("main", fmt.Sprintf("using %T for account storage", accountRepo))
 	adminServer.AddLivenessCheck(fmt.Sprintf("%s-accounts", accountStorageType), accountRepo.Ping)
 
 	// Setup Transaction storage

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -109,12 +109,14 @@ func main() {
 	// Setup Transaction storage
 	transactionStorageType := os.Getenv("TRANSACTION_STORAGE_TYPE")
 	if transactionStorageType == "" {
-		transactionStorageType = "qledger"
+		transactionStorageType = "sqlite"
 	}
-	transactionRepo, err := initTransactionStorage(transactionStorageType)
+	transactionRepo, err := initTransactionStorage(logger, transactionStorageType)
 	if err != nil {
 		panic(fmt.Sprintf("transaction storage: %v", err))
 	}
+	defer transactionRepo.Close()
+	logger.Log("main", fmt.Sprintf("using %T for transaction storage", transactionRepo))
 	adminServer.AddLivenessCheck(fmt.Sprintf("%s-transactions", transactionStorageType), transactionRepo.Ping)
 
 	// setup databases

--- a/cmd/server/sqlite.go
+++ b/cmd/server/sqlite.go
@@ -23,8 +23,7 @@ var (
 		`create table if not exists customers_addresses(customer_id, type, address1, address2, city, state, postal_code, country, validated, active, unique (customer_id, address1) on conflict abort);`,
 
 		// Account tables
-		`create table if not exists accounts(account_id primary key, customer_id, name, account_number, routing_number, status, type, created_at datetime, closed_at datetime, last_modified datetime, deleted_at datetime);`,
-		// TODO(adam): make unique constraint on (account_number, routing_number) and (account_id, customer_id)
+		`create table if not exists accounts(account_id primary key, customer_id, name, account_number, routing_number, status, type, created_at datetime, closed_at datetime, last_modified datetime, deleted_at datetime, unique(account_number, routing_number));`,
 	}
 )
 

--- a/cmd/server/sqlite.go
+++ b/cmd/server/sqlite.go
@@ -24,6 +24,10 @@ var (
 
 		// Account tables
 		`create table if not exists accounts(account_id primary key, customer_id, name, account_number, routing_number, status, type, created_at datetime, closed_at datetime, last_modified datetime, deleted_at datetime, unique(account_number, routing_number));`,
+
+		// Transaction tables
+		`create table if not exists transactions(transaction_id primart key, timestamp datetime, created_at datetime, deleted_at datetime);`,
+		`create table if not exists transaction_lines(transaction_id, account_id, purpose, amount integer, created_at datetime, deleted_at datetime, unique(transaction_id, account_id));`,
 	}
 )
 

--- a/cmd/server/transaction_storage.go
+++ b/cmd/server/transaction_storage.go
@@ -7,19 +7,24 @@ package main
 import (
 	"os"
 	"strings"
+
+	"github.com/go-kit/kit/log"
 )
 
 type transactionRepository interface {
 	Ping() error
+	Close() error
 
 	createTransaction(tx transaction) error
-	getAccountTransactions(accountID string) ([]transaction, error)
+	getAccountTransactions(accountID string) ([]transaction, error) // TODO(adam): limit and/or pagination params
 }
 
-func initTransactionStorage(name string) (transactionRepository, error) {
+func initTransactionStorage(logger log.Logger, name string) (transactionRepository, error) {
 	switch strings.ToLower(name) {
 	case "qledger":
 		return setupQLedgerTransactionStorage(os.Getenv("QLEDGER_ENDPOINT"), os.Getenv("QLEDGER_AUTH_TOKEN"))
+	case "sqlite":
+		return setupSqliteTransactionStorage(logger, getSqlitePath())
 	}
 	return nil, nil
 }

--- a/cmd/server/transaction_storage.go
+++ b/cmd/server/transaction_storage.go
@@ -34,3 +34,13 @@ func initTransactionStorage(logger log.Logger, name string) (transactionReposito
 	}
 	return nil, nil
 }
+
+// grabAccountIds returns an []string of each accountId from an array of transactionLines.
+// We do this to query transactions that have been posted against an account.
+func grabAccountIds(lines []transactionLine) []string {
+	var out []string
+	for i := range lines {
+		out = append(out, lines[i].AccountId)
+	}
+	return out
+}

--- a/cmd/server/transaction_storage.go
+++ b/cmd/server/transaction_storage.go
@@ -15,8 +15,14 @@ type transactionRepository interface {
 	Ping() error
 	Close() error
 
-	createTransaction(tx transaction) error
+	createTransaction(tx transaction, opts createTransactionOpts) error
 	getAccountTransactions(accountID string) ([]transaction, error) // TODO(adam): limit and/or pagination params
+}
+
+type createTransactionOpts struct {
+	// AllowOverdraft is an option on creating a transaction where GL will let the account 'go negative'
+	// and extend credit from the FI to the customer.
+	AllowOverdraft bool
 }
 
 func initTransactionStorage(logger log.Logger, name string) (transactionRepository, error) {

--- a/cmd/server/transaction_storage_qledger.go
+++ b/cmd/server/transaction_storage_qledger.go
@@ -30,6 +30,10 @@ func (r *qledgerTransactionRepository) Ping() error {
 	return r.api.Ping()
 }
 
+func (r *qledgerTransactionRepository) Close() error {
+	return nil
+}
+
 // grabAccountIds returns an []string of each accountId from an array of transactionLines.
 // We do this to query transactions that have been posted against an account.
 func grabAccountIds(lines []transactionLine) []string {

--- a/cmd/server/transaction_storage_qledger.go
+++ b/cmd/server/transaction_storage_qledger.go
@@ -44,7 +44,7 @@ func grabAccountIds(lines []transactionLine) []string {
 	return out
 }
 
-func (r *qledgerTransactionRepository) createTransaction(tx transaction) error {
+func (r *qledgerTransactionRepository) createTransaction(tx transaction, opts createTransactionOpts) error {
 	var lines []*mledge.TransactionLine
 	data := make(map[string]interface{})
 	data["accountIds"] = grabAccountIds(tx.Lines)

--- a/cmd/server/transaction_storage_qledger.go
+++ b/cmd/server/transaction_storage_qledger.go
@@ -34,16 +34,6 @@ func (r *qledgerTransactionRepository) Close() error {
 	return nil
 }
 
-// grabAccountIds returns an []string of each accountId from an array of transactionLines.
-// We do this to query transactions that have been posted against an account.
-func grabAccountIds(lines []transactionLine) []string {
-	var out []string
-	for i := range lines {
-		out = append(out, lines[i].AccountId)
-	}
-	return out
-}
-
 func (r *qledgerTransactionRepository) createTransaction(tx transaction, opts createTransactionOpts) error {
 	var lines []*mledge.TransactionLine
 	data := make(map[string]interface{})

--- a/cmd/server/transaction_storage_qledger_test.go
+++ b/cmd/server/transaction_storage_qledger_test.go
@@ -98,7 +98,7 @@ func TestQLedgerTransactions(t *testing.T) {
 		},
 	}).asTransaction(base.ID())
 
-	if err := transactionRepo.createTransaction(tx); err != nil {
+	if err := transactionRepo.createTransaction(tx, createTransactionOpts{AllowOverdraft: false}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/server/transaction_storage_qledger_test.go
+++ b/cmd/server/transaction_storage_qledger_test.go
@@ -42,6 +42,9 @@ func qualifyQLedgerTransactionTest(t *testing.T) *testQLedgerTransactionReposito
 	if repo == nil || err != nil {
 		t.Fatalf("repo=%v error=%v", repo, err)
 	}
+	if err := repo.Close(); err != nil { // should do nothing, so call in every test to make sure
+		t.Fatal("QLedger .Close() is a no-op")
+	}
 	return &testQLedgerTransactionRepository{repo, deployment}
 }
 

--- a/cmd/server/transaction_storage_qledger_test.go
+++ b/cmd/server/transaction_storage_qledger_test.go
@@ -39,8 +39,8 @@ func qualifyQLedgerTransactionTest(t *testing.T) *testQLedgerTransactionReposito
 
 	// repo, err := setupQLedgerTransactionStorage("https://api.moov.io/v1/qledger", "moov") // Test against Production
 	repo, err := setupQLedgerTransactionStorage(fmt.Sprintf("http://localhost:%s", deployment.qledger.GetPort("7000/tcp")), "moov")
-	if err != nil {
-		t.Fatal(err)
+	if repo == nil || err != nil {
+		t.Fatalf("repo=%v error=%v", repo, err)
 	}
 	return &testQLedgerTransactionRepository{repo, deployment}
 }

--- a/cmd/server/transaction_storage_sqlite.go
+++ b/cmd/server/transaction_storage_sqlite.go
@@ -1,0 +1,199 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/kit/log"
+)
+
+type sqliteTransactionRepository struct {
+	db     *sql.DB
+	logger log.Logger
+}
+
+func setupSqliteTransactionStorage(logger log.Logger, path string) (*sqliteTransactionRepository, error) {
+	db, err := createSqliteConnection(logger, path)
+	if err != nil {
+		return nil, err
+	}
+	return &sqliteTransactionRepository{db, logger}, nil
+}
+
+func (r *sqliteTransactionRepository) Ping() error {
+	return r.db.Ping()
+}
+
+func (r *sqliteTransactionRepository) Close() error {
+	return r.db.Close()
+}
+
+func (r *sqliteTransactionRepository) createTransaction(t transaction) error {
+	if err := t.validate(); err != nil {
+		return fmt.Errorf("transaction=%q is invalid: %v", t.ID, err)
+	}
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return fmt.Errorf("createTransaction: tx.Begin: %v", err)
+	}
+
+	// insert transaction
+	query := `insert into transactions(transaction_id, timestamp, created_at) values (?, ?, ?);`
+	stmt, err := tx.Prepare(query)
+	if err != nil {
+		return fmt.Errorf("createTransaction: prepare: error=%v rollback=%v", err, tx.Rollback())
+	}
+	if _, err := stmt.Exec(t.ID, t.Timestamp, time.Now()); err != nil {
+		stmt.Close()
+		return fmt.Errorf("createTransaction: insert: error=%v rollback=%v", err, tx.Rollback())
+	}
+	stmt.Close()
+
+	// insert each transactionLine
+	for i := range t.Lines {
+		query = `insert into transaction_lines(transaction_id, account_id, purpose, amount, created_at) values (?, ?, ?, ?, ?);`
+		stmt, err = tx.Prepare(query)
+		if err != nil {
+			stmt.Close()
+			return fmt.Errorf("createTransaction: transaction=%q account=%q prepare: error=%v rollback=%v", t.ID, t.Lines[i].AccountId, err, tx.Rollback())
+		}
+		if _, err := stmt.Exec(t.ID, t.Lines[i].AccountId, t.Lines[i].Purpose, t.Lines[i].Amount, time.Now()); err != nil {
+			stmt.Close()
+			return fmt.Errorf("createTransaction: transaction=%q account=%q insert: error=%v rollback=%v", t.ID, t.Lines[i].AccountId, err, tx.Rollback())
+		}
+		stmt.Close()
+
+		// // Check account balance, and if we're negative by less than t.Lines[i].Amount then we need to rollback as that account
+		// // didn't have sufficient funds to post the transaction.
+		// //
+		// // TODO(adam): How well does this actually work?
+		// balance, err := r.getAccountBalance(tx, t.Lines[i].AccountId)
+		// if err != nil {
+		// 	return fmt.Errorf("createTransaction: getAccountBalance: transaction=%q account=%q: err=%v rollback=%v", t.ID, t.Lines[i].AccountId, err, tx.Rollback())
+		// }
+		// if balance > 0 {
+		// 	fmt.Printf("account=%q balance=%d\n", t.Lines[i].AccountId, balance)
+		// 	continue // account has sufficient funds
+		// } else {
+		// 	// The current account balance is negative, so if that balance is less negative than the transaction amount that means the
+		// 	// account was overdrawn (i.e. insufficient funds). If the balances are equal then we also ran out of funds.
+		// 	if balance <= int64(t.Lines[i].Amount) {
+		// 		return fmt.Errorf("acocunt=%q has insufficient funds: rollback=%v", t.Lines[i].AccountId, tx.Rollback())
+		// 	}
+		// }
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("createTransaction: commit: %v", err)
+	}
+	return nil
+}
+
+func (r *sqliteTransactionRepository) getAccountTransactions(accountId string) ([]transaction, error) {
+	tx, err := r.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("getAccountTransactions: %v", err)
+	}
+
+	query := `select distinct transaction_id from transaction_lines where account_id = ? order by created_at desc;`
+	stmt, err := tx.Prepare(query)
+	if err != nil {
+		return nil, fmt.Errorf("getAccountTransactions: prepare: error=%v rollback=%v", err, tx.Rollback())
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(accountId)
+	if err != nil {
+		return nil, fmt.Errorf("getAccountTransactions: query: error=%v rollback=%v", err, tx.Rollback())
+	}
+	defer rows.Close()
+
+	var transactionIds []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("getAccountTransactions: scan: error=%v rollback=%v", err, tx.Rollback())
+		}
+		transactionIds = append(transactionIds, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("getAccountTransactions: err: error=%v rollback=%v", err, tx.Rollback())
+	}
+
+	var transactions []transaction
+	for i := range transactionIds {
+		t, err := r.getTransaction(tx, transactionIds[i])
+		if err != nil {
+			return nil, fmt.Errorf("getAccountTransactions: looping: error=%v rollback=%v", err, tx.Rollback())
+		}
+		transactions = append(transactions, *t)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("getAccountTransactions: commit: error=%v rollback=%v", err, tx.Rollback())
+	}
+	return transactions, nil
+}
+
+func (r *sqliteTransactionRepository) getTransaction(tx *sql.Tx, transactionId string) (*transaction, error) {
+	query := `select timestamp from transactions where transaction_id = ? and deleted_at is null limit 1;`
+	stmt, err := tx.Prepare(query)
+	if err != nil {
+		return nil, fmt.Errorf("getTransaction: timestamp: %v", err)
+	}
+	var timestamp time.Time
+	if err := stmt.QueryRow(transactionId).Scan(&timestamp); err != nil {
+		stmt.Close()
+		return nil, fmt.Errorf("getTransaction: timestamp query: %v", err)
+	}
+	stmt.Close() // close to prevent leaks
+
+	query = `select account_id, purpose, amount from transaction_lines where transaction_id = ? and deleted_at is null`
+	stmt, err = tx.Prepare(query)
+	if err != nil {
+		return nil, fmt.Errorf("getTransaction: %v", err)
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(transactionId)
+	if err != nil {
+		return nil, fmt.Errorf("getTransaction: query: %v", err)
+	}
+	defer rows.Close()
+
+	var lines []transactionLine
+	for rows.Next() {
+		var line transactionLine
+		if err := rows.Scan(&line.AccountId, &line.Purpose, &line.Amount); err != nil {
+			return nil, fmt.Errorf("getTransaction: scan transaction=%q account=%q: %v", transactionId, line.AccountId, err)
+		}
+		lines = append(lines, line)
+	}
+	return &transaction{
+		ID:        transactionId,
+		Timestamp: timestamp,
+		Lines:     lines,
+	}, rows.Err()
+}
+
+func (r *sqliteTransactionRepository) getAccountBalance(tx *sql.Tx, accountId string) (int64, error) {
+	// TODO(adam): At some point we should probably checkpoint balances so we avoid an entire index scan on an account_id
+	query := `select coalesce(sum(amount), 0) from transaction_lines where account_id = ? and deleted_at is null;`
+	stmt, err := tx.Prepare(query)
+	if err != nil {
+		return 0, err
+	}
+	defer stmt.Close()
+
+	var amount int64
+	if err := stmt.QueryRow(accountId).Scan(&amount); err != nil {
+		return 0, err
+	}
+	return amount, nil
+}

--- a/cmd/server/transaction_storage_sqlite_test.go
+++ b/cmd/server/transaction_storage_sqlite_test.go
@@ -1,0 +1,99 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/moov-io/base"
+
+	"github.com/go-kit/kit/log"
+)
+
+type testSqliteTransactionRepository struct {
+	*sqliteTransactionRepository
+
+	db *testSqliteDB
+}
+
+func (r *testSqliteTransactionRepository) Close() error {
+	r.db.close()
+	return r.sqliteTransactionRepository.Close()
+}
+
+func createTestSqliteTransactionRepository(t *testing.T) *testSqliteTransactionRepository {
+	t.Helper()
+
+	db, err := createTestSqliteDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := setupSqliteTransactionStorage(log.NewNopLogger(), filepath.Join(db.dir, "gl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &testSqliteTransactionRepository{repo, db}
+}
+
+func TestSqliteTransactionRepository__Ping(t *testing.T) {
+	repo := createTestSqliteTransactionRepository(t)
+	defer repo.Close()
+
+	if err := repo.Ping(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSqliteTransactionRepository(t *testing.T) {
+	repo := createTestSqliteTransactionRepository(t)
+	defer repo.Close()
+
+	account1, account2 := base.ID(), base.ID()
+	tx := transaction{
+		ID:        base.ID(),
+		Timestamp: time.Now(),
+		Lines: []transactionLine{
+			{
+				AccountId: account1,
+				Purpose:   ACHDebit,
+				Amount:    -500,
+			},
+			{
+				AccountId: account2,
+				Purpose:   ACHCredit,
+				Amount:    500,
+			},
+		},
+	}
+	if err := repo.createTransaction(tx); err != nil {
+		t.Fatal(err)
+	}
+
+	transactions, err := repo.getAccountTransactions(account1)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(transactions) != 1 {
+		t.Errorf("got %d transactions: %v", len(transactions), transactions)
+	}
+	if transactions[0].ID != tx.ID || len(transactions[0].Lines) != 2 {
+		t.Errorf("%#v", transactions[0])
+	}
+
+	dbtx, _ := repo.db.db.Begin()
+
+	bal, err := repo.getAccountBalance(dbtx, account1)
+	if err != nil || bal != -500 {
+		t.Errorf("got balance of %d", bal)
+	}
+	bal, err = repo.getAccountBalance(dbtx, account2)
+	if err != nil || bal != 500 {
+		t.Errorf("got balance of %d", bal)
+	}
+}
+
+// TODO(adam): Check we handle insufficient funds

--- a/cmd/server/transaction_storage_sqlite_test.go
+++ b/cmd/server/transaction_storage_sqlite_test.go
@@ -69,7 +69,7 @@ func TestSqliteTransactionRepository(t *testing.T) {
 			},
 		},
 	}
-	if err := repo.createTransaction(tx); err != nil {
+	if err := repo.createTransaction(tx, createTransactionOpts{AllowOverdraft: true}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/server/transactions.go
+++ b/cmd/server/transactions.go
@@ -67,6 +67,17 @@ type transaction struct {
 	Lines     []transactionLine `json:"lines"`
 }
 
+func (t transaction) validate() error {
+	sum := 0
+	for i := range t.Lines {
+		sum += t.Lines[i].Amount
+	}
+	if sum == 0 {
+		return nil
+	}
+	return fmt.Errorf("transaction=%s has %d invalid lines sum=%d", t.ID, len(t.Lines), sum)
+}
+
 func addTransactionRoutes(logger log.Logger, router *mux.Router, accountRepo accountRepository, transactionRepo transactionRepository) {
 	router.Methods("GET").Path("/accounts/{accountId}/transactions").HandlerFunc(getAccountTransactions(logger, transactionRepo))
 	router.Methods("POST").Path("/accounts/{accountId}/transactions").HandlerFunc(createTransaction(logger, accountRepo, transactionRepo))

--- a/cmd/server/transactions.go
+++ b/cmd/server/transactions.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/moov-io/base"
 	moovhttp "github.com/moov-io/base/http"
-	"github.com/moov-io/gl"
 
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
@@ -141,22 +140,9 @@ func createTransaction(logger log.Logger, accountRepo accountRepository, transac
 			return
 		}
 
-		tx := req.asTransaction(base.ID())
-
-		// Naive balance check on transactions.
-		// TODO(adam): This is a bad compare, we need to attempt a commit with balance checks
-		accounts, err := accountRepo.GetAccounts(grabAccountIds(tx.Lines))
-		if err != nil {
-			moovhttp.Problem(w, err)
-			return
-		}
-		if err := checkBalance(accounts, tx); err != nil {
-			moovhttp.Problem(w, err)
-			return
-		}
-
 		// Post the transaction
-		if err := transactionRepo.createTransaction(tx); err != nil {
+		tx := req.asTransaction(base.ID())
+		if err := transactionRepo.createTransaction(tx, createTransactionOpts{AllowOverdraft: false}); err != nil {
 			moovhttp.Problem(w, err)
 			return
 		}
@@ -165,27 +151,4 @@ func createTransaction(logger log.Logger, accountRepo accountRepository, transac
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(tx)
 	}
-}
-
-func checkBalance(accounts []*gl.Account, tx transaction) error {
-	if len(accounts) < 2 || len(tx.Lines) == 0 {
-		return fmt.Errorf("checkBalance: invalid input len(accounts)=%d len(tx.Lines)=%d", len(accounts), len(tx.Lines))
-	}
-	for i := range accounts {
-		if accounts[i].Balance > 0 {
-			for j := range tx.Lines {
-				if accounts[i].ID == tx.Lines[j].AccountId {
-					if accounts[i].Balance < int64(tx.Lines[j].Amount) {
-						return fmt.Errorf("checkBalance: account %s has insufficient funds", accounts[i].ID)
-					} else {
-						goto sufficient
-					}
-				}
-			}
-			// no match, logic bug or database bug
-			return fmt.Errorf("checkBalance: no transactionLines found for account %s", accounts[i].ID)
-		}
-	sufficient: // Account had sufficient funds
-	}
-	return nil
 }

--- a/cmd/server/transactions.go
+++ b/cmd/server/transactions.go
@@ -68,6 +68,16 @@ type transaction struct {
 }
 
 func (t transaction) validate() error {
+	if t.ID == "" {
+		return errors.New("transaction: empty ID")
+	}
+	if len(t.Lines) == 0 {
+		return fmt.Errorf("transaction=%q has no Lines", t.ID)
+	}
+	if t.Timestamp.IsZero() {
+		return fmt.Errorf("transaction=%q has no Timestamp", t.ID)
+	}
+
 	sum := 0
 	for i := range t.Lines {
 		sum += t.Lines[i].Amount

--- a/cmd/server/transactions_test.go
+++ b/cmd/server/transactions_test.go
@@ -31,6 +31,10 @@ func (r *mockTransactionRepository) Ping() error {
 	return r.err
 }
 
+func (r *mockTransactionRepository) Close() error {
+	return r.err
+}
+
 func (r *mockTransactionRepository) createTransaction(tx transaction) error {
 	return r.err
 }

--- a/cmd/server/transactions_test.go
+++ b/cmd/server/transactions_test.go
@@ -63,6 +63,53 @@ func TestTransactionPurpose(t *testing.T) {
 	}
 }
 
+func TestTransaction__validate(t *testing.T) {
+	tx := transaction{
+		ID:        base.ID(),
+		Timestamp: time.Now(),
+		Lines: []transactionLine{
+			{
+				AccountId: base.ID(),
+				Purpose:   ACHDebit,
+				Amount:    -500,
+			},
+			{
+				AccountId: base.ID(),
+				Purpose:   ACHCredit,
+				Amount:    500,
+			},
+		},
+	}
+	if err := tx.validate(); err != nil {
+		t.Error(err)
+	}
+
+	// make invalid
+	tx.ID = ""
+	if err := tx.validate(); err == nil {
+		t.Error("expected error")
+	}
+	tx.ID = base.ID()
+
+	var empty time.Time
+	tx.Timestamp = empty
+	if err := tx.validate(); err == nil {
+		t.Error("expected error")
+	}
+	tx.Timestamp = time.Now()
+
+	tx.Lines[0].Amount = 1
+	if err := tx.validate(); err == nil {
+		t.Error("expected error")
+	}
+	tx.Lines[0].Amount = -500
+
+	tx.Lines = []transactionLine{}
+	if err := tx.validate(); err == nil {
+		t.Error("expected error")
+	}
+}
+
 func TestTransactions_getAccountId(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/foo", nil)

--- a/cmd/server/transactions_test.go
+++ b/cmd/server/transactions_test.go
@@ -35,7 +35,10 @@ func (r *mockTransactionRepository) Close() error {
 	return r.err
 }
 
-func (r *mockTransactionRepository) createTransaction(tx transaction) error {
+func (r *mockTransactionRepository) createTransaction(tx transaction, _ createTransactionOpts) error {
+	if err := tx.validate(); err != nil {
+		return err
+	}
 	return r.err
 }
 
@@ -225,7 +228,7 @@ func TestTransactions_Create(t *testing.T) {
 	json.NewEncoder(&body).Encode(createTransactionRequest{
 		Lines: []transactionLine{
 			{AccountId: accountRepo.accounts[0].ID, Purpose: ACHDebit, Amount: -4121},
-			{AccountId: accountRepo.accounts[1].ID, Purpose: ACHCredit, Amount: -121},
+			{AccountId: accountRepo.accounts[1].ID, Purpose: ACHCredit, Amount: 4121},
 		},
 	})
 	req := httptest.NewRequest("POST", "/accounts/foo/transactions", &body)
@@ -272,6 +275,7 @@ func TestTransactions_CreateInvalid(t *testing.T) {
 	var body bytes.Buffer
 	json.NewEncoder(&body).Encode(createTransactionRequest{
 		Lines: []transactionLine{
+			// Invalid Lines will force an error
 			{AccountId: base.ID(), Purpose: ACHDebit, Amount: -4121},
 			{AccountId: base.ID(), Purpose: ACHCredit, Amount: -121},
 		},
@@ -285,58 +289,5 @@ func TestTransactions_CreateInvalid(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("got %d", w.Code)
-	}
-}
-
-func TestTransactions__checkBalance(t *testing.T) {
-	accounts := []*gl.Account{
-		{
-			ID:      base.ID(),
-			Balance: 1000, // $10
-		},
-		{
-			ID:      base.ID(),
-			Balance: 10000, // $100
-		},
-	}
-	tx := transaction{
-		ID: base.ID(),
-		Lines: []transactionLine{
-			{
-				AccountId: accounts[0].ID,
-				Purpose:   ACHDebit,
-				Amount:    500,
-			},
-			{
-				AccountId: accounts[1].ID,
-				Purpose:   ACHDebit,
-				Amount:    -500,
-			},
-		},
-	}
-	if err := checkBalance(accounts, tx); err != nil {
-		t.Fatal(err)
-	}
-
-	// invalid inputs
-	if err := checkBalance(nil, tx); err == nil {
-		t.Error("expected error")
-	}
-	if err := checkBalance(accounts, transaction{ID: base.ID()}); err == nil {
-		t.Error("expected error")
-	}
-
-	// Check with some accounts missing
-	acct := *accounts[0]
-	acct.ID = base.ID() // copy our account with sufficient balance, but mixup the ID (so it won't match the tx.Lines)
-	if err := checkBalance([]*gl.Account{&acct, accounts[1]}, tx); err == nil {
-		t.Error("expected error")
-	}
-
-	// Try with insufficient balance
-	tx.Lines[0].Amount = 1100
-	tx.Lines[1].Amount = -1100
-	if err := checkBalance(accounts, tx); err == nil {
-		t.Error("expected error")
 	}
 }

--- a/gl.go
+++ b/gl.go
@@ -70,10 +70,11 @@ type Account struct {
 	// Type is the account type: Checking, Savings, FBO
 	Type string `json:"type"`
 
-	CreatedAt    time.Time `json:"createdAt"`
-	ClosedAt     time.Time `json:"closedAt"`
-	LastModified time.Time `json:"lastModified"`
+	CreatedAt    time.Time  `json:"createdAt"`
+	ClosedAt     *time.Time `json:"closedAt"`
+	LastModified *time.Time `json:"lastModified"`
 
+	// Computed fields
 	Balance          int64 `json:"balance"`
 	BalanceAvailable int64 `json:"balanceAvailable"`
 	BalancePending   int64 `json:"balancePending"`


### PR DESCRIPTION
Storage with QLedger doesn't work as there isn't a way to enforce that an account never gets a transaction posted to it which would push the account into 'insufficient funds'. Instead I added a [naive and racy check in the HTTP endpoints](https://github.com/moov-io/gl/blob/master/cmd/server/transactions.go#L125). Using sqlite and committing one large transaction does allow for this atomic commit or rollback. 