### PR TITLE
cmd/server: add 'balance' to account creation to track initial balance

### DIFF
--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -377,9 +377,16 @@ components:
   schemas:
     CreateAccount:
       example:
+        balance: 1000
         name: Super Checking
         type: Checking
       properties:
+        balance:
+          description: Initial balance of account in USD cents. This amount is to
+            be deposited from an account at another Financial Institution or in-person
+            (i.e. cash) on account creation.
+          example: 1000
+          type: integer
         name:
           description: Caller defined label for this account.
           example: Super Checking
@@ -392,6 +399,7 @@ components:
           - FBO
           type: string
       required:
+      - balance
       - name
       - type
       type: object

--- a/client/docs/CreateAccount.md
+++ b/client/docs/CreateAccount.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Balance** | **int32** | Initial balance of account in USD cents. This amount is to be deposited from an account at another Financial Institution or in-person (i.e. cash) on account creation. | 
 **Name** | **string** | Caller defined label for this account. | 
 **Type** | **string** | Product type of the account | 
 

--- a/client/model_create_account.go
+++ b/client/model_create_account.go
@@ -10,6 +10,8 @@
 package openapi
 
 type CreateAccount struct {
+	// Initial balance of account in USD cents. This amount is to be deposited from an account at another Financial Institution or in-person (i.e. cash) on account creation.
+	Balance int32 `json:"balance"`
 	// Caller defined label for this account.
 	Name string `json:"name"`
 	// Product type of the account

--- a/cmd/server/accounts_test.go
+++ b/cmd/server/accounts_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/moov-io/base"
 	"github.com/moov-io/gl"
 
+	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
 )
 
@@ -37,10 +38,16 @@ func init() {
 }
 
 func TestAccounts__createAccountRequest(t *testing.T) {
-	req := createAccountRequest{"example acct", "checking"}
+	req := createAccountRequest{100, "example acct", "checking"} // $1
 	if err := req.validate(); err != nil {
 		t.Error(err)
 	}
+
+	req.Balance = 10 // $0.10
+	if err := req.validate(); err == nil {
+		t.Error("expected error")
+	}
+	req.Balance = 1000
 
 	req.Type = "SavInGs" // valid
 	if err := req.validate(); err != nil {
@@ -55,17 +62,19 @@ func TestAccounts__createAccountRequest(t *testing.T) {
 
 func TestAccounts__CreateAccount(t *testing.T) {
 	w := httptest.NewRecorder()
-	body := strings.NewReader(`{"customerId": "foo", "name": "Money", "type": "Savings"}`)
+	body := strings.NewReader(`{"balance": 1000, "name": "Money", "type": "Savings"}`)
 	req := httptest.NewRequest("POST", "/customers/foo/accounts", body)
 	req.Header.Set("x-user-id", "test")
 
+	transactionRepo := &mockTransactionRepository{}
+
 	router := mux.NewRouter()
-	addAccountRoutes(nil, router, mockAccountRepo)
+	addAccountRoutes(log.NewNopLogger(), router, mockAccountRepo, transactionRepo)
 	router.ServeHTTP(w, req)
 	w.Flush()
 
 	if w.Code != http.StatusOK {
-		t.Errorf("bogus status code: %d", w.Code)
+		t.Errorf("bogus status code: %d:\n  %s", w.Code, w.Body.String())
 	}
 
 	var acct gl.Account // TODO(adam): check more of Customer response?
@@ -82,8 +91,10 @@ func TestAccounts__GetCustomerAccounts(t *testing.T) {
 	req := httptest.NewRequest("GET", "/customers/foo/accounts", nil)
 	req.Header.Set("x-user-id", "test")
 
+	transactionRepo := &mockTransactionRepository{}
+
 	router := mux.NewRouter()
-	addAccountRoutes(nil, router, mockAccountRepo)
+	addAccountRoutes(log.NewNopLogger(), router, mockAccountRepo, transactionRepo)
 	router.ServeHTTP(w, req)
 	w.Flush()
 
@@ -108,8 +119,10 @@ func TestAccounts__SearchAccounts(t *testing.T) {
 	req := httptest.NewRequest("GET", "/accounts/search?number=1&routingNumber=123&type=Savings", nil)
 	req.Header.Set("x-user-id", "test")
 
+	transactionRepo := &mockTransactionRepository{}
+
 	router := mux.NewRouter()
-	addAccountRoutes(nil, router, mockAccountRepo)
+	addAccountRoutes(log.NewNopLogger(), router, mockAccountRepo, transactionRepo)
 	router.ServeHTTP(w, req)
 	w.Flush()
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -127,7 +127,7 @@ func main() {
 	router := mux.NewRouter()
 	moovhttp.AddCORSHandler(router)
 	addPingRoute(logger, router)
-	addAccountRoutes(logger, router, accountRepo)
+	addAccountRoutes(logger, router, accountRepo, transactionRepo)
 	addCustomerRoutes(logger, router, customerRepo)
 	addTransactionRoutes(logger, router, accountRepo, transactionRepo)
 

--- a/cmd/server/transaction_storage.go
+++ b/cmd/server/transaction_storage.go
@@ -23,6 +23,11 @@ type createTransactionOpts struct {
 	// AllowOverdraft is an option on creating a transaction where GL will let the account 'go negative'
 	// and extend credit from the FI to the customer.
 	AllowOverdraft bool
+
+	// InitialDeposit is an option for allowing the transaction validation to be bypassed in order
+	// to onboard on account. This is done to initially add funds into an account, but we don't track where the
+	// funds come from on the transaction level.
+	InitialDeposit bool
 }
 
 func initTransactionStorage(logger log.Logger, name string) (transactionRepository, error) {

--- a/cmd/server/transaction_storage_sqlite.go
+++ b/cmd/server/transaction_storage_sqlite.go
@@ -59,7 +59,7 @@ func isInteranlDebit(accounts []*gl.Account, lines []transactionLine, glRoutingN
 }
 
 func (r *sqliteTransactionRepository) createTransaction(t transaction, opts createTransactionOpts) error {
-	if err := t.validate(); err != nil {
+	if err := t.validate(); err != nil && !opts.InitialDeposit {
 		return fmt.Errorf("transaction=%q is invalid: %v", t.ID, err)
 	}
 

--- a/cmd/server/transactions_test.go
+++ b/cmd/server/transactions_test.go
@@ -35,8 +35,8 @@ func (r *mockTransactionRepository) Close() error {
 	return r.err
 }
 
-func (r *mockTransactionRepository) createTransaction(tx transaction, _ createTransactionOpts) error {
-	if err := tx.validate(); err != nil {
+func (r *mockTransactionRepository) createTransaction(tx transaction, opts createTransactionOpts) error {
+	if err := tx.validate(); err != nil && !opts.InitialDeposit {
 		return err
 	}
 	return r.err

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -314,9 +314,14 @@ components:
     CreateAccount:
       type: object
       required:
+        - balance
         - name
         - type
       properties:
+        balance:
+          type: integer
+          description: Initial balance of account in USD cents. This amount is to be deposited from an account at another Financial Institution or in-person (i.e. cash) on account creation.
+          example: 1000
         name:
           type: string
           description: Caller defined label for this account.


### PR DESCRIPTION
This helps solve the chicken-and-egg problem where accounts can't get
a balance and thus are useless. I'm unsure if we'll actually need to
track the debit half of the transaction in the future (it would always
be an external FI or cash deposit).